### PR TITLE
Potential fix for code scanning alert no. 8: Resolving XML external entity in user-controlled data

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyXmlModuleDescriptorParser.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyXmlModuleDescriptorParser.java
@@ -1345,18 +1345,19 @@ public class IvyXmlModuleDescriptorParser extends AbstractModuleDescriptorParser
 
         private static SAXParser newSAXParser(URL schema, InputStream schemaStream)
                 throws ParserConfigurationException, SAXException {
+            SAXParserFactory parserFactory = XmlFactories.newSAXParserFactory();
+            parserFactory.setNamespaceAware(true);
+            parserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            parserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+
             if (schema == null) {
-                SAXParserFactory parserFactory = XmlFactories.newSAXParserFactory();
                 parserFactory.setValidating(false);
-                parserFactory.setNamespaceAware(true);
                 SAXParser parser = parserFactory.newSAXParser();
                 parser.getXMLReader().setFeature(XML_NAMESPACE_PREFIXES, true);
                 return parser;
             } else {
-                SAXParserFactory parserFactory = XmlFactories.newSAXParserFactory();
                 parserFactory.setValidating(true);
-                parserFactory.setNamespaceAware(true);
-
                 SAXParser parser = parserFactory.newSAXParser();
                 parser.setProperty(JAXP_SCHEMA_LANGUAGE, W3C_XML_SCHEMA);
                 parser.setProperty(JAXP_SCHEMA_SOURCE, schemaStream);


### PR DESCRIPTION
Potential fix for [https://github.com/alemaodacapa/gradle/security/code-scanning/8](https://github.com/alemaodacapa/gradle/security/code-scanning/8)

To fix the problem, we need to configure the `SAXParserFactory` to disable external entity expansion. This involves setting specific features on the `SAXParserFactory` to prevent the parser from processing external entities. The best way to fix this without changing existing functionality is to update the `newSAXParser` method to include these configurations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
